### PR TITLE
Exercese10

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -18,7 +18,7 @@ class PasswordResetsController < ApplicationController
       render 'new'
     end
   end
-    
+;    
   def edit
   end
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -18,7 +18,7 @@ class PasswordResetsController < ApplicationController
       render 'new'
     end
   end
-;    
+    
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,12 @@ class UsersController < ApplicationController
   before_action :admin_user, only: :destroy
   
   def index
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end    
   
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated? == true
 #    debugger
   end
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,7 @@ class User < ActiveRecord::Base
 
   # Activates an account.
   def activate
-    update_attribute(:activated,    true)
-    update_attribute(:activated_at, Time.zone.now)
+    update_columns(activated: true, activated_at: Time.zone.now)
   end
 
   # Sends activation email.
@@ -54,8 +53,8 @@ class User < ActiveRecord::Base
   # Sets the password reset attributes.
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attribute(:reset_digest, User.digest(reset_token))
-    update_attribute(:reset_sent_at, Time.zone.now)
+    update_columns(reset_digest:  User.digest(reset_token),
+                   reset_sent_at: Time.zone.now)
   end
 
   ## Sends password reset email.

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -59,4 +59,20 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     assert_redirected_to user
   end
+
+  test "expired token" do
+    get new_password_reset_path
+    post password_resets_path, password_reset: { email: @user.email }
+
+    @user = assigns(:user)
+    @user.update_attribute(:reset_sent_at, 3.hours.ago)
+    patch password_reset_path(@user.reset_token),
+          email: @user.email,
+          user: { password:              "foobar",
+                  password_confirmation: "foobar" }
+    assert_response :redirect
+    follow_redirect!
+    assert_match /expired./i, response.body
+  end
+    
 end

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -72,7 +72,7 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
                   password_confirmation: "foobar" }
     assert_response :redirect
     follow_redirect!
-    assert_match /expired./i, response.body
+    assert_match /expired\./i, response.body
   end
     
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'test_helper'
 
 class UsersIndexTest < ActionDispatch::IntegrationTest
@@ -29,4 +30,26 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     get users_path
     assert_select 'a', text: 'delete', count: 0
   end
+
+  test "/users/:id activated" do
+    log_in_as(@admin) #ログインする
+    get user_path(@non_admin) #@non_adminのプロフィールを見に行く
+    assert_template 'users/show' #プロフィールが表示されていることを確認
+  end
+
+  test "/users/:id inactivated" do
+    log_in_as(@admin) #ログインする
+    @non_admin.update_attribute(:activated, false)  #@non_adminのactivatedをfalseにする
+    get user_path(@non_admin) #@non_adminのプロフィールを見に行く
+    follow_redirect!
+    assert_template 'static_pages/home' #homeが表示されていることを確認
+  end
+
+  test "/users" do
+    log_in_as(@admin) #ログインする
+    @non_admin.update_attribute(:activated, false)  #@non_adminのactivateをfalseにする
+    get users_path  #usersを見る
+    assert_select 'a[href=?]', user_path(@non_admin), text: @non_admin.name, count: 0  #@non_adminが表示されていないことを確認 
+  end
+  
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -48,8 +48,12 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
   test "/users" do
     log_in_as(@admin) #ログインする
     @non_admin.update_attribute(:activated, false)  #@non_adminのactivateをfalseにする
-    get users_path  #usersを見る
-    assert_select 'a[href=?]', user_path(@non_admin), text: @non_admin.name, count: 0  #@non_adminが表示されていないことを確認 
+    get users_path
+    i = assigns(:users).total_pages
+    for page in 1..i do
+      get users_path, page: page   #usersを見る
+      assert_select 'a[href=?]', user_path(@non_admin), text: @non_admin.name, count: 0  #@non_adminが表示されていないことを確認
+    end
   end
   
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -49,8 +49,7 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     log_in_as(@admin) #ログインする
     @non_admin.update_attribute(:activated, false)  #@non_adminのactivateをfalseにする
     get users_path
-    i = assigns(:users).total_pages
-    for page in 1..i do
+    1.upto assigns(:users).total_pages do |page|
       get users_path, page: page   #usersを見る
       assert_select 'a[href=?]', user_path(@non_admin), text: @non_admin.name, count: 0  #@non_adminが表示されていないことを確認
     end


### PR DESCRIPTION
# やること
## 10.1
- [x] パスワードリセットメールが期限切れの場合のテストを書く。

## 10.2
- [x] ユーザの一覧では有効化されたユーザのみ表示されるようにする。
- [x] ユーザの一覧とユーザプロフィールの結合テストを書く。

## 10.3
- [x] `activate`メソッドと`create_reset_digest`メソッド内で`update_attribute`メソッドを2回呼び出している箇所があるので、`update_columns`メソッドを1回呼び出すことで済むように書き換える。


# 完了条件
- [x] テストが通る。
- [x] 2人以上に :ok_hand: をもらう。